### PR TITLE
Bugfix/hexcolors updated

### DIFF
--- a/ExampleProject/Example/TSDemoViewController.m
+++ b/ExampleProject/Example/TSDemoViewController.m
@@ -65,7 +65,8 @@
                                                                      type:TSMessageNotificationTypeSuccess];
                                  }
                                      atPosition:TSMessageNotificationPositionTop
-                           canBeDismissedByUser:YES];
+                           canBeDismissedByUser:YES
+                                      textAlign:NSTextAlignmentCenter];
 }
 
 - (IBAction)didTapToggleNavigationBar:(id)sender {
@@ -92,7 +93,8 @@
                                     buttonTitle:nil
                                  buttonCallback:nil
                                      atPosition:TSMessageNotificationPositionTop
-                           canBeDismissedByUser:YES];
+                           canBeDismissedByUser:YES
+                                      textAlign:NSTextAlignmentCenter];
 }
 
 - (IBAction)didTapDismissCurrentMessage:(id)sender
@@ -112,7 +114,8 @@
                                     buttonTitle:nil
                                  buttonCallback:nil
                                      atPosition:TSMessageNotificationPositionTop
-                            canBeDismissedByUser:NO];
+                            canBeDismissedByUser:NO
+                                      textAlign:NSTextAlignmentCenter];
 }
 
 - (IBAction)didTapLong:(id)sender
@@ -127,7 +130,8 @@
                                     buttonTitle:nil
                                  buttonCallback:nil
                                      atPosition:TSMessageNotificationPositionTop
-                           canBeDismissedByUser:YES];
+                           canBeDismissedByUser:YES
+                                      textAlign:NSTextAlignmentCenter];
 }
 
 - (IBAction)didTapBottom:(id)sender
@@ -142,7 +146,8 @@
                                     buttonTitle:nil
                                  buttonCallback:nil
                                      atPosition:TSMessageNotificationPositionBottom
-                            canBeDismissedByUser:YES];
+                            canBeDismissedByUser:YES
+                                      textAlign:NSTextAlignmentCenter];
 }
 
 - (IBAction)didTapText:(id)sender

--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -182,7 +182,14 @@ __weak static UIViewController *_defaultViewController;
         {
             [currentNavigationController.view insertSubview:currentView
                                                belowSubview:[currentNavigationController navigationBar]];
-            verticalOffset = MAX([currentNavigationController navigationBar].bounds.size.height, CGRectGetHeight(currentView.viewController.navigationItem.titleView.bounds));
+                                               
+            NSArray *titleViewsBounds = [currentView.viewController.navigationController.viewControllers valueForKeyPath:@"navigationItem.titleView.bounds"];
+            __block CGFloat maxTitleViewHeight = 0.0;
+            [titleViewsBounds enumerateObjectsUsingBlock:^(NSValue *boundsValue, NSUInteger idx, BOOL *stop) {
+                CGRect rect = boundsValue.CGRectValue;
+                maxTitleViewHeight = CGRectGetHeight(rect) > maxTitleViewHeight ? CGRectGetHeight(rect) : maxTitleViewHeight;
+            }];
+            verticalOffset = MAX([currentNavigationController navigationBar].bounds.size.height, maxTitleViewHeight);
             if ([TSMessage iOS7StyleEnabled] || isViewIsUnderStatusBar) {
                 addStatusBarHeightToVerticalOffset();
             }

--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -182,7 +182,7 @@ __weak static UIViewController *_defaultViewController;
         {
             [currentNavigationController.view insertSubview:currentView
                                                belowSubview:[currentNavigationController navigationBar]];
-            verticalOffset = [currentNavigationController navigationBar].bounds.size.height;
+            verticalOffset = MAX([currentNavigationController navigationBar].bounds.size.height, CGRectGetHeight(currentView.viewController.navigationItem.titleView.bounds));
             if ([TSMessage iOS7StyleEnabled] || isViewIsUnderStatusBar) {
                 addStatusBarHeightToVerticalOffset();
             }

--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -186,7 +186,7 @@ __weak static UIViewController *_defaultViewController;
             NSArray *titleViewsBounds = [currentView.viewController.navigationController.viewControllers valueForKeyPath:@"navigationItem.titleView.bounds"];
             __block CGFloat maxTitleViewHeight = 0.0;
             [titleViewsBounds enumerateObjectsUsingBlock:^(NSValue *boundsValue, NSUInteger idx, BOOL *stop) {
-                CGRect rect = boundsValue.CGRectValue;
+                CGRect rect = [boundsValue isEqual:NSNull.null] ? CGRectZero : boundsValue.CGRectValue;
                 maxTitleViewHeight = CGRectGetHeight(rect) > maxTitleViewHeight ? CGRectGetHeight(rect) : maxTitleViewHeight;
             }];
             verticalOffset = MAX([currentNavigationController navigationBar].bounds.size.height, maxTitleViewHeight);

--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -8,7 +8,6 @@
 
 #import "TSMessageView.h"
 #import "HexColor.h"
-#import "TSBlurView.h"
 #import "TSMessage.h"
 
 
@@ -45,7 +44,7 @@ static NSMutableDictionary *_notificationDesign;
 @property (nonatomic, strong) UIButton *button;
 @property (nonatomic, strong) UIView *borderView;
 @property (nonatomic, strong) UIImageView *backgroundImageView;
-@property (nonatomic, strong) TSBlurView *backgroundBlurView; // Only used in iOS 7
+@property (nonatomic, strong) UIView *backgroundView; // Only used in iOS 7
 
 @property (nonatomic, assign) CGFloat textSpaceLeft;
 @property (nonatomic, assign) CGFloat textSpaceRight;
@@ -162,12 +161,10 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         }
         else
         {
-            // On iOS 7 and above use a blur layer instead (not yet finished)
-            _backgroundBlurView = [[TSBlurView alloc] init];
-            self.backgroundBlurView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
-            self.backgroundBlurView.blurTintColor = [UIColor colorWithHexString:current[@"backgroundColor"]];
-            self.backgroundBlurView.alpha = current[@"backgroundAlpha"] ? [current[@"backgroundAlpha"] floatValue] : 1.0;
-            [self addSubview:self.backgroundBlurView];
+            _backgroundView = [[UIView alloc] init];
+            self.backgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
+            self.backgroundView.backgroundColor = [UIColor colorWithHexString:current[@"backgroundColor"] alpha:current[@"backgroundAlpha"] ? [current[@"backgroundAlpha"] floatValue] : 1.0];
+            [self addSubview:self.backgroundView];
         }
         
         UIColor *fontColor = [UIColor colorWithHexString:[current valueForKey:@"textColor"]
@@ -462,7 +459,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
     }
 
     self.backgroundImageView.frame = backgroundFrame;
-    self.backgroundBlurView.frame = backgroundFrame;
+    self.backgroundView.frame = backgroundFrame;
     
     return currentHeight;
 }

--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -166,6 +166,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             _backgroundBlurView = [[TSBlurView alloc] init];
             self.backgroundBlurView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
             self.backgroundBlurView.blurTintColor = [UIColor colorWithHexString:current[@"backgroundColor"]];
+            self.backgroundBlurView.alpha = current[@"backgroundAlpha"] ? [current[@"backgroundAlpha"] floatValue] : 1.0;
             [self addSubview:self.backgroundBlurView];
         }
         

--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -7,7 +7,7 @@
 //
 
 #import "TSMessageView.h"
-#import "HexColor.h"
+#import "HexColors.h"
 #import "TSMessage.h"
 
 

--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -428,8 +428,22 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
     }
 
 
+    NSArray *titleViewsBounds = [self.viewController.navigationController.viewControllers valueForKeyPath:@"navigationItem.titleView.bounds"];
+    __block CGFloat maxTitleViewHeight = 0.0;
+    CGFloat differenceHeight = 0.0;
+    [titleViewsBounds enumerateObjectsUsingBlock:^(NSValue *boundsValue, NSUInteger idx, BOOL *stop) {
+        CGRect rect = [boundsValue isEqual:NSNull.null] ? CGRectZero : boundsValue.CGRectValue;
+        maxTitleViewHeight = CGRectGetHeight(rect) > maxTitleViewHeight ? CGRectGetHeight(rect) : maxTitleViewHeight;
+    }];
+    
+    if (maxTitleViewHeight > currentHeight)
+    {
+        differenceHeight = maxTitleViewHeight - currentHeight;
+        currentHeight += differenceHeight;
+    }
+
     CGRect backgroundFrame = CGRectMake(self.backgroundImageView.frame.origin.x,
-                                        self.backgroundImageView.frame.origin.y,
+                                        MIN(self.backgroundImageView.frame.origin.y, -differenceHeight),
                                         screenWidth,
                                         currentHeight);
 


### PR DESCRIPTION
TSMessage has a dependency with 'HexColors'.

HexColors in 2.3 version has renamed his file hexColor.h to hexColors.h
Also, now we can align the text in the TSMessage
- Rename import hexColors.h in TSMessageView
- Update in methods with textAlign property in the TSDemoViewController
